### PR TITLE
removing default for foreign key field because it throws an error with mysql.

### DIFF
--- a/cas_provider/migrations/0002_auto_20140920_1644.py
+++ b/cas_provider/migrations/0002_auto_20140920_1644.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='proxygrantingticket',
             name='user',
-            field=models.ForeignKey(default=0, verbose_name='user', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL),
             preserve_default=False,
         ),
     ]


### PR DESCRIPTION
MySQL won't accept a value of 0 for an auto increment field. 
